### PR TITLE
Update validated-method.js

### DIFF
--- a/validated-method.js
+++ b/validated-method.js
@@ -24,21 +24,32 @@ ValidatedMethod = class ValidatedMethod {
 
     const method = this;
     this.connection.methods({
-      [name](args) {
+      [name]() {
         // Silence audit-argument-checks since arguments are always checked when using this package
-        check(args, Match.Any);
+        check(arguments, Match.Any);
         const methodInvocation = this;
-        return method._execute(methodInvocation, args);
+        return method._execute(methodInvocation, arguments);
       }
     });
   }
 
-  call(args, callback) {
+  call() {
+    var args = arguments;
     // Accept calling with just a callback
-    if (_.isFunction(args)) {
+    if (args.length == 1 && _.isFunction(args[0])) {
       callback = args;
-      args = {};
+      args = [];
+    } else {
+      // if it's a function, the last argument is the result callback,
+      // not a parameter to the remote method.
+      if (args.length && typeof args[args.length - 1] === "function") {
+        var callback = args.pop();
+      }
     }
+    
+    var args = arguments;
+    
+    return this.apply(name, args, callback);
 
     const options = {
       // Make it possible to get the ID of an inserted item
@@ -52,7 +63,7 @@ ValidatedMethod = class ValidatedMethod {
     };
 
     try {
-      return this.connection.apply(this.name, [args], options, callback);
+      return this.connection.apply(this.name, args, options, callback);
     } catch (err) {
       // Get errors from the stub in the same way as from the server-side method
       callback(err);
@@ -60,13 +71,13 @@ ValidatedMethod = class ValidatedMethod {
   }
 
   _execute(methodInvocation, args) {
-    const validateResult = this.validate.bind(methodInvocation)(args);
+    const validateResult = this.validate.apply(methodInvocation, args);
 
     if (typeof validateResult !== 'undefined') {
       throw new Error(`Returning from validate doesn't do anything; \
 perhaps you meant to throw an error?`);
     }
 
-    return this.run.bind(methodInvocation)(args);
+    return this.run.apply(methodInvocation, args);
   }
 };


### PR DESCRIPTION
Allow support for more than one parameter being passed to Meteor.method -

For example:
var formId = 'XXXXX';
var formModifierObj = {$set:{blue:true}};
 Meteor.call('updateForm', formId, formModifierObj);
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/meteor/validated-method/pull/17%23issuecomment-162957940%22%2C%20%22https%3A//github.com/meteor/validated-method/pull/17%23issuecomment-162975554%22%2C%20%22https%3A//github.com/meteor/validated-method/pull/17%23issuecomment-162976730%22%2C%20%22https%3A//github.com/meteor/validated-method/pull/17%23issuecomment-162985140%22%2C%20%22https%3A//github.com/meteor/validated-method/pull/17%23issuecomment-162989751%22%2C%20%22https%3A//github.com/meteor/validated-method/pull/17%23issuecomment-162993802%22%2C%20%22https%3A//github.com/meteor/validated-method/pull/17%23issuecomment-163000977%22%2C%20%22https%3A//github.com/meteor/validated-method/pull/17%23issuecomment-163084956%22%2C%20%22https%3A//github.com/meteor/validated-method/pull/17%23issuecomment-163145379%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/validated-method/pull/17%23issuecomment-162957940%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40okland%20I%27m%20open%20to%20a%20discussion%20around%20this%2C%20but%20having%20keyword%20arguments%20only%20was%20an%20intentional%20decision.%20In%20ES2015%20it%27s%20very%20easy%20to%20pass%20and%20accept%20keyword%20arguments%20into%20a%20function%2C%20so%20there%20is%20almost%20no%20benefit%20to%20ordered%20arguments.%20The%20benefits%20of%20keyword%20arguments%20are%3A%5Cr%5Cn%5Cr%5Cn1.%20You%20can%20validate%20all%20of%20the%20arguments%20with%20one%20schema%20object%5Cr%5Cn2.%20You%20can%20easily%20map%20method%20arguments%20onto%20a%20form%5Cr%5Cn3.%20You%20can%20pass%20around%20all%20of%20the%20arguments%20as%20one%20object%20without%20having%20to%20hack%20arrays%5Cr%5Cn4.%20You%20can%20easily%20add%20more%20arguments%20to%20the%20method%20without%20making%20your%20code%20more%20complex%5Cr%5Cn%5Cr%5CnFor%20your%20code%20sample%2C%20the%20correct%20way%20to%20call%20the%20method%20would%20be%3A%5Cr%5Cn%5Cr%5Cn%60%60%60js%5Cr%5CnForm.methods.update.call%28%7B%5Cr%5Cn%20%20formId%3A%20%60XXXX%60%2C%5Cr%5Cn%20%20fieldsToSet%3A%20%7B%20blue%3A%20true%20%7D%5Cr%5Cn%7D%29%3B%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnIn%20the%20method%20body%20you%20can%20easily%20get%20the%20arguments%20like%20this%3A%5Cr%5Cn%5Cr%5Cn%60%60%60js%5Cr%5Cnrun%28%7B%20formId%2C%20fieldsToSet%20%7D%29%20%7B%5Cr%5Cn%20%20...%5Cr%5Cn%7D%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5CnAlso%2C%20note%20that%20the%20code%20you%20have%20has%20an%20issue%20where%20you%20are%20passing%20a%20MongoDB%20update%20operator%20from%20the%20client.%20These%20are%20notoriously%20hard%20to%20validate%2C%20so%20I%20would%20suggest%20passing%20a%20dictionary%20of%20fields%20to%20set%20instead.%20Read%20this%20section%20for%20details%3A%20http%3A//guide.meteor.com/security.html%23specific-action%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-12-08T17%3A43%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40stubailo%20%20Tnx%20for%20the%20response%2C%5Cr%5CnI%20totally%20agree%20with%20everything%20you%20mentioned%2C%20keyboard%20arguments%20is%20also%20my%20preferred%20way%20to%20use%20as%20method%20input.%20%5Cr%5Cn%5Cr%5CnIt%20just%20that%20while%20trying%20to%20use%20the%20package%20in%20practice%20i%20encounter%20the%20case%20of%20the%20example%20mentioned%20above.%20While%20using%20AutoForm%20method-update%2C%20AutoForm%20package%20calls%20a%20method%20with%20ordered%20arguments%20%2C%20I%20would%20have%20loved%20to%20use%20the%20clean%20use%20of%20validated-method%20even%20to%20respond%20to%20that%20case%2C%20so%20i%20think%20that%20a%20solution%20that%20promotes%20keyboard%20arguments%20as%20default%20but%20can%20also%20be%20used%20with%20ordered%20arguments%20might%20solve%20this%20case.%20%20%22%2C%20%22created_at%22%3A%20%222015-12-08T18%3A41%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1032524%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/okland%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20While%20using%20AutoForm%20method-update%2C%20AutoForm%20package%20calls%20a%20method%20with%20ordered%20arguments%20%5Cr%5Cn%5Cr%5CnThat%27s%20interesting%20-%20I%20didn%27t%20know%20about%20this%20mode%2C%20I%20was%20using%20the%20%60method%60%20mode.%20I%20guess%20that%20makes%20sense%20-%20while%20we%20can%20promote%20the%20keyword%20argument%20use%20case%2C%20there%27s%20no%20technical%20reason%20we%20can%27t%20support%20ordered%20arguments%20as%20well.%20But%20in%20this%20case%2C%20you%20can%27t%20use%20the%20nice%20%60SimpleSchema%23validator%60%20function.%5Cr%5Cn%5Cr%5Cn%40aldeed%20what%20do%20you%20think%3F%20Should%20we%20update%20autoform%20to%20send%20different%20arguments%2C%20or%20have%20a%20version%20of%20%60validator%60%20that%20takes%20ordered%20arguments%3F%22%2C%20%22created_at%22%3A%20%222015-12-08T18%3A45%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah%2C%20I%27m%20aware%20of%20this%20and%20my%20plan%20is%20to%20have%20an%20option%20per%20form%20that%20would%20tell%20it%20to%20call%20the%20method%20with%20a%20single%20object%20arg.%22%2C%20%22created_at%22%3A%20%222015-12-08T19%3A11%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3012067%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aldeed%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40aldeed%20any%20ETA%20on%20that%20kind%20of%20feature%3F%20Would%20it%20be%20weeks%2C%20months%3F%22%2C%20%22created_at%22%3A%20%222015-12-08T19%3A29%3A16Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40stubailo%20It%20is%20easy%20and%20backward%20compatible%20so%20I%27ll%20try%20to%20find%20some%20time%20this%20week.%22%2C%20%22created_at%22%3A%20%222015-12-08T19%3A45%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3012067%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aldeed%22%7D%7D%2C%20%7B%22body%22%3A%20%22OK%20keep%20me%20posted%21%20Thanks.%22%2C%20%22created_at%22%3A%20%222015-12-08T20%3A08%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40okland%20%40stubailo%20https%3A//github.com/aldeed/meteor-autoform/releases/tag/v5.8.0%22%2C%20%22created_at%22%3A%20%222015-12-09T02%3A14%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3012067%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/aldeed%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40aldeed%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-12-09T08%3A04%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1032524%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/okland%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/validated-method/pull/17#issuecomment-162957940'>General Comment</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> @okland I'm open to a discussion around this, but having keyword arguments only was an intentional decision. In ES2015 it's very easy to pass and accept keyword arguments into a function, so there is almost no benefit to ordered arguments. The benefits of keyword arguments are:
- You can validate all of the arguments with one schema object
- You can easily map method arguments onto a form
- You can pass around all of the arguments as one object without having to hack arrays
- You can easily add more arguments to the method without making your code more complex
  For your code sample, the correct way to call the method would be:

``` js
Form.methods.update.call({
formId: `XXXX`,
fieldsToSet: { blue: true }
});
```

In the method body you can easily get the arguments like this:

``` js
run({ formId, fieldsToSet }) {
...
}
```

Also, note that the code you have has an issue where you are passing a MongoDB update operator from the client. These are notoriously hard to validate, so I would suggest passing a dictionary of fields to set instead. Read this section for details: http://guide.meteor.com/security.html#specific-action
- <a href='https://github.com/okland'><img border=0 src='https://avatars.githubusercontent.com/u/1032524?v=3' height=16 width=16'></a> @stubailo  Tnx for the response,
  I totally agree with everything you mentioned, keyboard arguments is also my preferred way to use as method input.
  It just that while trying to use the package in practice i encounter the case of the example mentioned above. While using AutoForm method-update, AutoForm package calls a method with ordered arguments , I would have loved to use the clean use of validated-method even to respond to that case, so i think that a solution that promotes keyboard arguments as default but can also be used with ordered arguments might solve this case.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> > While using AutoForm method-update, AutoForm package calls a method with ordered arguments
  That's interesting - I didn't know about this mode, I was using the `method` mode. I guess that makes sense - while we can promote the keyword argument use case, there's no technical reason we can't support ordered arguments as well. But in this case, you can't use the nice `SimpleSchema#validator` function.
  @aldeed what do you think? Should we update autoform to send different arguments, or have a version of `validator` that takes ordered arguments?
- <a href='https://github.com/aldeed'><img border=0 src='https://avatars.githubusercontent.com/u/3012067?v=3' height=16 width=16'></a> Yeah, I'm aware of this and my plan is to have an option per form that would tell it to call the method with a single object arg.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> @aldeed any ETA on that kind of feature? Would it be weeks, months?
- <a href='https://github.com/aldeed'><img border=0 src='https://avatars.githubusercontent.com/u/3012067?v=3' height=16 width=16'></a> @stubailo It is easy and backward compatible so I'll try to find some time this week.
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> OK keep me posted! Thanks.
- <a href='https://github.com/aldeed'><img border=0 src='https://avatars.githubusercontent.com/u/3012067?v=3' height=16 width=16'></a> @okland @stubailo https://github.com/aldeed/meteor-autoform/releases/tag/v5.8.0
- <a href='https://github.com/okland'><img border=0 src='https://avatars.githubusercontent.com/u/1032524?v=3' height=16 width=16'></a> @aldeed :+1:

<a href='https://www.codereviewhub.com/meteor/validated-method/pull/17?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/meteor/validated-method/pull/17?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/meteor/validated-method/pull/17'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
