### PR TITLE
Throw error when one of the mixins doesn't return options object.

### DIFF
--- a/validated-method-tests.js
+++ b/validated-method-tests.js
@@ -53,6 +53,15 @@ const methodWithSchemaMixin = new ValidatedMethod({
   }
 });
 
+const faultyMixinOptions = {
+  name: 'methodWithFaultySchemaMixin',
+  mixins: [function nonReturningFunction() {}],
+  schema: null,
+  run() {
+    return 'result';
+  }
+};
+
 function schemaMixin(methodOptions) {
   methodOptions.validate = methodOptions.schema.validator();
   return methodOptions;
@@ -112,6 +121,12 @@ describe('mdg:method', () => {
 
       done();
     });
+  });
+
+  it('throws error if a mixin does not return the options object', () => {
+    assert.throws(() => {
+      new ValidatedMethod(faultyMixinOptions);
+    }, /didn't return the options object/);
   });
 
   it('has access to the name on this.name', (done) => {

--- a/validated-method-tests.js
+++ b/validated-method-tests.js
@@ -53,15 +53,6 @@ const methodWithSchemaMixin = new ValidatedMethod({
   }
 });
 
-const faultyMixinOptions = {
-  name: 'methodWithFaultySchemaMixin',
-  mixins: [function nonReturningFunction() {}],
-  schema: null,
-  run() {
-    return 'result';
-  }
-};
-
 function schemaMixin(methodOptions) {
   methodOptions.validate = methodOptions.schema.validator();
   return methodOptions;
@@ -125,8 +116,26 @@ describe('mdg:method', () => {
 
   it('throws error if a mixin does not return the options object', () => {
     assert.throws(() => {
-      new ValidatedMethod(faultyMixinOptions);
-    }, /didn't return the options object/);
+      new ValidatedMethod({
+        name: 'methodWithFaultySchemaMixin',
+        mixins: [function nonReturningFunction() {}],
+        schema: null,
+        run() {
+          return 'result';
+        }
+      });
+    }, /Error in methodWithFaultySchemaMixin method: The function 'nonReturningFunction' didn't return the options object/);
+
+    assert.throws(() => {
+      new ValidatedMethod({
+        name: 'methodWithFaultySchemaMixin',
+        mixins: [function (args) { return args}, function () {}],
+        schema: null,
+        run() {
+          return 'result';
+        }
+      });
+    }, /Error in methodWithFaultySchemaMixin method: One of the mixins didn't return the options object/);
   });
 
   it('has access to the name on this.name', (done) => {

--- a/validated-method.js
+++ b/validated-method.js
@@ -5,6 +5,7 @@ ValidatedMethod = class ValidatedMethod {
     // Default to no mixins
     options.mixins = options.mixins || [];
     check(options.mixins, [Function]);
+    check(options.name, String);
     options = applyMixins(options, options.mixins);
 
     // connection argument defaults to Meteor, which is where Methods are defined on client and
@@ -91,6 +92,8 @@ perhaps you meant to throw an error?`);
 function applyMixins(args, mixins) {
   // You can pass nested arrays so that people can ship mixin packs
   const flatMixins = _.flatten(mixins);
+  // Save name of the method here, so we can attach it to potential error messages
+  const {name} = args;
 
   flatMixins.forEach((mixin) => {
     args = mixin(args);
@@ -103,7 +106,7 @@ function applyMixins(args, mixins) {
         msg = `The function '${functionName[1]}'`;
       }
 
-      throw new Error(`${msg} didn't return the options object.`);
+      throw new Error(`Error in ${name} method: ${msg} didn't return the options object.`);
     }
   });
 

--- a/validated-method.js
+++ b/validated-method.js
@@ -94,6 +94,17 @@ function applyMixins(args, mixins) {
 
   flatMixins.forEach((mixin) => {
     args = mixin(args);
+
+    if(!Match.test(args, Object)) {
+      const functionName = mixin.toString().match(/function\s(\w+)/);
+      let msg = 'One of the mixins';
+
+      if(functionName) {
+        msg = `The function '${functionName[1]}'`;
+      }
+
+      throw new Error(`${msg} didn't return the options object.`);
+    }
   });
 
   return args;


### PR DESCRIPTION
Fixes #23.

@stubailo I'm throwing inside of the `applyMixins` function instantly if the mixin in the `forEach` callback isn't returning a plain object.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/meteor/validated-method/pull/24%23issuecomment-170425477%22%2C%20%22https%3A//github.com/meteor/validated-method/pull/24%23issuecomment-170425505%22%2C%20%22https%3A//github.com/meteor/validated-method/pull/24%23issuecomment-170877037%22%2C%20%22https%3A//github.com/meteor/validated-method/pull/24%23issuecomment-170969287%22%2C%20%22https%3A//github.com/meteor/validated-method/pull/24%23issuecomment-171001702%22%2C%20%22https%3A//github.com/meteor/validated-method/pull/24%23issuecomment-171003079%22%2C%20%22https%3A//github.com/meteor/validated-method/pull/24%23issuecomment-171003263%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/meteor/validated-method/pull/24%23issuecomment-170425477%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hmm%2C%20this%20is%20making%20me%20think%20that%20all%20mixins%20should%20have%20a%20well-defined%20%60name%60%20property.%20Also%2C%20it%27s%20weird%20that%20the%20stack%20trace%20in%20this%20error%20will%20actually%20show%20the%20%60validated-method%60%20package%2C%20so%20in%20the%20worst%20case%20you%27ll%20get%20%5C%22One%20of%20the%20mixins%20didn%27t%20return%20an%20options%20object%5C%22%20and%20the%20trace%20will%20be%20from%20this%20package.%20I%20guess%20you%20will%20be%20able%20to%20use%20that%20to%20figure%20out%20which%20method%20it%20is.%5Cr%5Cn%5Cr%5CnThoughts%3F%22%2C%20%22created_at%22%3A%20%222016-01-11T03%3A41%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20thinking%20at%20the%20least%20the%20error%20message%20should%20include%20the%20%60name%60%20of%20the%20ValidatedMethod%20in%20which%20the%20mixin%20was%20used%2C%20if%20such%20exists.%22%2C%20%22created_at%22%3A%20%222016-01-11T03%3A42%3A28Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3E%20Hmm%2C%20this%20is%20making%20me%20think%20that%20all%20mixins%20should%20have%20a%20well-defined%20name%20property.%5Cr%5Cn%5Cr%5CnI%20hear%20you%2C%20but%20it%20might%20take%20the%20simplicity%20with%20%5C%22it%27s%20just%20functions%5C%22%20away.%5Cr%5Cn%5Cr%5Cn%3E%20I%27m%20thinking%20at%20the%20least%20the%20error%20message%20should%20include%20the%20name%20of%20the%20ValidatedMethod%20in%20which%20the%20mixin%20was%20used%2C%20if%20such%20exists.%5Cr%5Cn%5Cr%5CnYes%2C%20that%27s%20valid%20%3A%29%20I%27ll%20fix.%5Cr%5Cn%5Cr%5CnAt%20least%20the%20trace%20will%20point%20to%20the%20location%20where%20the%20%60ValidatedMethod%60%20was%20instantiated.%20And%20it%20might%20perhaps%20be%20possible%20to%20pass%20the%20mixin%20in%20question%20as%20a%20parameter%20to%20the%20%60Error%60%20thrown%2C%20as%20an%20extra%20data%20item%3F%22%2C%20%22created_at%22%3A%20%222016-01-12T11%3A03%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/437261%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/johanbrook%22%7D%7D%2C%20%7B%22body%22%3A%20%22Nah%20I%20think%20you%27re%20right%20-%20for%20now%20just%20adding%20the%20name%20of%20the%20method%20will%20be%20fine.%22%2C%20%22created_at%22%3A%20%222016-01-12T16%3A40%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40stubailo%20Pushed.%5Cr%5Cn%5Cr%5CnAs%20you%20can%20see%20in%20the%20tests%2C%20the%20error%20messages%20are%20now%3A%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5CnError%20in%20methodWithFaultySchemaMixin%20method%3A%20The%20function%20%27nonReturningFunction%27%20didn%27t%20return%20the%20options%20object%5Cr%5Cn%60%60%60%5Cr%5Cn%5Cr%5Cnresp.%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5CnError%20in%20methodWithFaultySchemaMixin%20method%3A%20One%20of%20the%20mixins%20didn%27t%20return%20the%20options%20object%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222016-01-12T18%3A22%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/437261%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/johanbrook%22%7D%7D%2C%20%7B%22body%22%3A%20%22Looks%20great%21%22%2C%20%22created_at%22%3A%20%222016-01-12T18%3A27%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/448783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/stubailo%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Azap%3A%20%3Asmile%3A%20%22%2C%20%22created_at%22%3A%20%222016-01-12T18%3A28%3A25Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/437261%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/johanbrook%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/meteor/validated-method/pull/24#issuecomment-170425477'>General Comment</a></b>
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Hmm, this is making me think that all mixins should have a well-defined `name` property. Also, it's weird that the stack trace in this error will actually show the `validated-method` package, so in the worst case you'll get "One of the mixins didn't return an options object" and the trace will be from this package. I guess you will be able to use that to figure out which method it is.
  Thoughts?
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> I'm thinking at the least the error message should include the `name` of the ValidatedMethod in which the mixin was used, if such exists.
- <a href='https://github.com/johanbrook'><img border=0 src='https://avatars.githubusercontent.com/u/437261?v=3' height=16 width=16'></a> > Hmm, this is making me think that all mixins should have a well-defined name property.
  I hear you, but it might take the simplicity with "it's just functions" away.
  > I'm thinking at the least the error message should include the name of the ValidatedMethod in which the mixin was used, if such exists.
  Yes, that's valid :) I'll fix.
  At least the trace will point to the location where the `ValidatedMethod` was instantiated. And it might perhaps be possible to pass the mixin in question as a parameter to the `Error` thrown, as an extra data item?
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Nah I think you're right - for now just adding the name of the method will be fine.
- <a href='https://github.com/johanbrook'><img border=0 src='https://avatars.githubusercontent.com/u/437261?v=3' height=16 width=16'></a> @stubailo Pushed.
  As you can see in the tests, the error messages are now:

```
Error in methodWithFaultySchemaMixin method: The function 'nonReturningFunction' didn't return the options object
```

resp.

```
Error in methodWithFaultySchemaMixin method: One of the mixins didn't return the options object
```
- <a href='https://github.com/stubailo'><img border=0 src='https://avatars.githubusercontent.com/u/448783?v=3' height=16 width=16'></a> Looks great!
- <a href='https://github.com/johanbrook'><img border=0 src='https://avatars.githubusercontent.com/u/437261?v=3' height=16 width=16'></a> :zap: :smile:

<a href='https://www.codereviewhub.com/meteor/validated-method/pull/24?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/meteor/validated-method/pull/24?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/meteor/validated-method/pull/24'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
