### PR TITLE
Allow callOptions to be added when a validated method is created

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ const method = new ValidatedMethod({
   name, // DDP method name
   mixins, // Method extensions
   validate, // argument validation
-  callOptions, // options passed to Meteor.apply
+  applyOptions, // options passed to Meteor.apply
   run // Method body
 });
 
@@ -59,7 +59,7 @@ Lists.methods.makePrivate = new ValidatedMethod({
   // This is optional, but you can use this to pass options into Meteor.apply every
   // time this method is called.  This can be used, for instance, to ask meteor not
   // to retry this method if it fails.
-  callOptions: {
+  applyOptions: {
     noRetry: true,
   },
 
@@ -151,7 +151,7 @@ You can define a method on a non-default DDP connection by passing an extra `con
 
 #### Options to Meteor.apply
 
-The validated method, when called, executes itself via `Meteor.apply`.  The `apply` method also takes a few [options](http://docs.meteor.com/#/full/meteor_apply) which can be used to alter the way Meteor handles the method.  If you want to use those options you can supply them to the validated method when it is created, using the `callOptions` member.  Pass it an object that will be used with `Meteor.apply`.
+The validated method, when called, executes itself via `Meteor.apply`.  The `apply` method also takes a few [options](http://docs.meteor.com/#/full/meteor_apply) which can be used to alter the way Meteor handles the method.  If you want to use those options you can supply them to the validated method when it is created, using the `applyOptions` member.  Pass it an object that will be used with `Meteor.apply`.
 
 #### Secret server code
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ const method = new ValidatedMethod({
   name, // DDP method name
   mixins, // Method extensions
   validate, // argument validation
+  callOptions, // options passed to Meteor.apply
   run // Method body
 });
 
@@ -54,6 +55,13 @@ Lists.methods.makePrivate = new ValidatedMethod({
   validate: new SimpleSchema({
     listId: { type: String }
   }).validator(),
+
+  // This is optional, but you can use this to pass options into Meteor.apply every
+  // time this method is called.  This can be used, for instance, to ask meteor not
+  // to retry this method if it fails.
+  callOptions: {
+    noRetry: true,
+  },
 
   // This is the body of the method. Use ES2015 object destructuring to get
   // the keyword arguments
@@ -140,6 +148,10 @@ If your method does not need argument validation, perhaps because it does not ta
 #### Defining a method on a non-default connection
 
 You can define a method on a non-default DDP connection by passing an extra `connection` option to the constructor.
+
+#### Options to Meteor.apply
+
+The validated method, when called, executes itself via `Meteor.apply`.  The `apply` method also takes a few [options](http://docs.meteor.com/#/full/meteor_apply) which can be used to alter the way Meteor handles the method.  If you want to use those options you can supply them to the validated method when it is created, using the `callOptions` member.  Pass it an object that will be used with `Meteor.apply`.
 
 #### Secret server code
 

--- a/validated-method-tests.js
+++ b/validated-method-tests.js
@@ -54,10 +54,10 @@ const methodWithSchemaMixin = new ValidatedMethod({
 });
 
 let resultReceived = false;
-const methodWithCallOptions = new ValidatedMethod({
-  name: 'methodWithCallOptions',
+const methodWithApplyOptions = new ValidatedMethod({
+  name: 'methodWithApplyOptions',
   validate: new SimpleSchema({}).validator(),
-  callOptions: {
+  applyOptions: {
     onResultReceived: function() {
       resultReceived = true;
     }
@@ -171,7 +171,7 @@ describe('mdg:method', () => {
     }
 
     resultReceived = false;
-    methodWithCallOptions.call({}, (err, res) => {
+    methodWithApplyOptions.call({}, (err, res) => {
       // The Method knows its own name
       assert.equal(resultReceived, true);
 

--- a/validated-method-tests.js
+++ b/validated-method-tests.js
@@ -53,6 +53,20 @@ const methodWithSchemaMixin = new ValidatedMethod({
   }
 });
 
+let resultReceived = false;
+const methodWithCallOptions = new ValidatedMethod({
+  name: 'methodWithCallOptions',
+  validate: new SimpleSchema({}).validator(),
+  callOptions: {
+    onResultReceived: function() {
+      resultReceived = true;
+    }
+  },
+  run() {
+    return 'result';
+  }
+});
+
 function schemaMixin(methodOptions) {
   methodOptions.validate = methodOptions.schema.validator();
   return methodOptions;
@@ -145,6 +159,21 @@ describe('mdg:method', () => {
     methodReturnsName.call({}, (err, res) => {
       // The Method knows its own name
       assert.equal(res, 'methodReturnsName');
+
+      done();
+    });
+  });
+
+  it('can accept Meteor.apply options', (done) => {
+    if (Meteor.isServer) {
+      // the only apply option that I can think of to test is client side only
+      return done();
+    }
+
+    resultReceived = false;
+    methodWithCallOptions.call({}, (err, res) => {
+      // The Method knows its own name
+      assert.equal(resultReceived, true);
 
       done();
     });

--- a/validated-method.js
+++ b/validated-method.js
@@ -30,6 +30,19 @@ ValidatedMethod = class ValidatedMethod {
       callOptions: Object,
     }));
 
+    const defaultCallOptions = {
+      // Make it possible to get the ID of an inserted item
+      returnStubValue: true,
+
+      // Don't call the server method if the client stub throws an error, so that we don't end
+      // up doing validations twice
+      // XXX needs option to disable, in cases where the client might have incomplete information to
+      // make a decision
+      throwStubExceptions: true,
+    };
+
+    options.callOptions = _.extend(defaultCallOptions, options.callOptions);
+
     _.extend(this, options);
 
     const method = this;
@@ -50,15 +63,6 @@ ValidatedMethod = class ValidatedMethod {
       callback = args;
       args = {};
     }
-
-    // Make it possible to get the ID of an inserted item
-    this.callOptions.returnStubValue = true;
-
-    // Don't call the server method if the client stub throws an error, so that we don't end
-    // up doing validations twice
-    // XXX needs option to disable, in cases where the client might have incomplete information to
-    // make a decision
-    this.callOptions.throwStubExceptions = true;
 
     try {
       return this.connection.apply(this.name, [args], this.callOptions, callback);

--- a/validated-method.js
+++ b/validated-method.js
@@ -17,12 +17,17 @@ ValidatedMethod = class ValidatedMethod {
       options.validate = function () {};
     }
 
+    if (options.callOptions === undefined) {
+      options.callOptions = {};
+    }
+
     check(options, Match.ObjectIncluding({
       name: String,
       validate: Function,
       run: Function,
       mixins: [Function],
       connection: Object,
+      callOptions: Object,
     }));
 
     _.extend(this, options);
@@ -46,19 +51,17 @@ ValidatedMethod = class ValidatedMethod {
       args = {};
     }
 
-    const options = {
-      // Make it possible to get the ID of an inserted item
-      returnStubValue: true,
+    // Make it possible to get the ID of an inserted item
+    this.callOptions.returnStubValue = true;
 
-      // Don't call the server method if the client stub throws an error, so that we don't end
-      // up doing validations twice
-      // XXX needs option to disable, in cases where the client might have incomplete information to
-      // make a decision
-      throwStubExceptions: true
-    };
+    // Don't call the server method if the client stub throws an error, so that we don't end
+    // up doing validations twice
+    // XXX needs option to disable, in cases where the client might have incomplete information to
+    // make a decision
+    this.callOptions.throwStubExceptions = true;
 
     try {
-      return this.connection.apply(this.name, [args], options, callback);
+      return this.connection.apply(this.name, [args], this.callOptions, callback);
     } catch (err) {
       if (callback) {
         // Get errors from the stub in the same way as from the server-side method

--- a/validated-method.js
+++ b/validated-method.js
@@ -17,8 +17,8 @@ ValidatedMethod = class ValidatedMethod {
       options.validate = function () {};
     }
 
-    if (options.callOptions === undefined) {
-      options.callOptions = {};
+    if (options.applyOptions === undefined) {
+      options.applyOptions = {};
     }
 
     check(options, Match.ObjectIncluding({
@@ -27,10 +27,10 @@ ValidatedMethod = class ValidatedMethod {
       run: Function,
       mixins: [Function],
       connection: Object,
-      callOptions: Object,
+      applyOptions: Object,
     }));
 
-    const defaultCallOptions = {
+    const defaultApplyOptions = {
       // Make it possible to get the ID of an inserted item
       returnStubValue: true,
 
@@ -41,7 +41,7 @@ ValidatedMethod = class ValidatedMethod {
       throwStubExceptions: true,
     };
 
-    options.callOptions = _.extend({}, defaultCallOptions, options.callOptions);
+    options.applyOptions = _.extend({}, defaultApplyOptions, options.applyOptions);
 
     _.extend(this, options);
 
@@ -65,7 +65,7 @@ ValidatedMethod = class ValidatedMethod {
     }
 
     try {
-      return this.connection.apply(this.name, [args], this.callOptions, callback);
+      return this.connection.apply(this.name, [args], this.applyOptions, callback);
     } catch (err) {
       if (callback) {
         // Get errors from the stub in the same way as from the server-side method

--- a/validated-method.js
+++ b/validated-method.js
@@ -41,7 +41,7 @@ ValidatedMethod = class ValidatedMethod {
       throwStubExceptions: true,
     };
 
-    options.callOptions = _.extend(defaultCallOptions, options.callOptions);
+    options.callOptions = _.extend({}, defaultCallOptions, options.callOptions);
 
     _.extend(this, options);
 


### PR DESCRIPTION
FYI, I've signed the meteor contributor agreement.

I want to be able to send in an options object to be used in the `Meteor.apply` call of a validated method.  My goal is to use the `noRetry` option, but I made this change to allow any options to be passed in, so that it can be used for any current or future apply options that exist.  I added a test, but since the only option I could test was client side, the test doesn't do anything on the server side.
