### PR TITLE
Fix type of `mixins` option

### DIFF
--- a/validated-method.js
+++ b/validated-method.js
@@ -4,7 +4,9 @@ ValidatedMethod = class ValidatedMethod {
   constructor(options) {
     // Default to no mixins
     options.mixins = options.mixins || [];
-    check(options.mixins, [Function]);
+    const Mixins = [Match.OneOf(Function)];
+    Mixins[0].choices.push(Mixins);
+    check(options.mixins, Mixins);
     check(options.name, String);
     options = applyMixins(options, options.mixins);
 
@@ -24,7 +26,7 @@ ValidatedMethod = class ValidatedMethod {
       name: String,
       validate: Function,
       run: Function,
-      mixins: [Function],
+      mixins: Mixins,
       connection: Object,
       applyOptions: Object,
     }));


### PR DESCRIPTION
`Match error: Expected function, got object in field [0]`
This error occurs when I try to use nested arrays in `mixin` option.
As an alternative to this PR, I suggest to [flatten mixin array before type checking](https://github.com/Davidyuk/validated-method/commit/76c2f3528c505172eb6d13d1b7b8bacf1911670e).