### PR TITLE
Add callAsync method to validated method (untested)

### DIFF
--- a/validated-method.js
+++ b/validated-method.js
@@ -85,6 +85,10 @@ export class ValidatedMethod {
     }
   }
 
+  callAsync(args) {
+    return this.connection.applyAsync(this.name, [args], this.applyOptions);
+  }
+
   _execute(methodInvocation = {}, args) {
     // Add `this.name` to reference the Method name
     methodInvocation.name = this.name;


### PR DESCRIPTION
fix #90

I'm not able to run tests locally, so I haven't provided any tests for the new method. See rationale in #90.