### PR TITLE
Added a callAsync method

### DIFF
--- a/validated-method-tests.js
+++ b/validated-method-tests.js
@@ -72,6 +72,23 @@ const methodWithApplyOptions = new ValidatedMethod({
   }
 });
 
+const asyncMethod = new ValidatedMethod({
+  name: 'asyncMethod',
+  validate: new SimpleSchema({
+    param: { type: Number },
+  }).validator(),
+  async run({ param }) {
+    return new Promise(resolve => {
+		setTimeout(() => {
+			resolve(['result', 'result2', param]);
+		}, 1000);
+	})
+		.then(result => {
+			return result.join(',');
+		});
+  }
+});
+
 function schemaMixin(methodOptions) {
   methodOptions.validate = methodOptions.schema.validator();
   return methodOptions;
@@ -98,6 +115,14 @@ describe('mdg:method', () => {
         done();
       });
     });
+  });
+
+  it('allows methods to be called asynchronously', (done) => {
+    asyncMethod.callAsync({ param: 3000 })
+		.then(result => {
+		  assert.equal(result, 'result,result2,3000');
+		  done();
+		});
   });
 
 

--- a/validated-method.js
+++ b/validated-method.js
@@ -85,6 +85,43 @@ export class ValidatedMethod {
     }
   }
 
+  callAsync(args) {
+		//taken from the callAsync method internals which will use applyAsync with a isFromCallAsync param
+		//which will flag methods as running on DDP
+		//reset current method invocation and mark it as running
+		DDP._CurrentMethodInvocation._set();
+		DDP._CurrentMethodInvocation._setCallAsyncMethodRunning(true);
+
+		return new Promise((resolve, reject) => {
+			const clientResultOrThenable = this.connection.applyAsync(
+				this.name,
+				[args],
+				//ensure throwStubExceptions which we need in order
+				//to catch client exceptions and re-throw them as promise rejections
+				//mimic callAsync through isFromCallAsync
+				//merge with this.applyOptions
+				Object.assign(this.applyOptions, { throwStubExceptions: true, isFromCallAsync: true }),
+				(err, serverResult) => {
+					//set the current invocation running to false as soon as server returned its
+					//promise so that subsequent methods in .then's of the first method run in their
+					//own context instead of thinking they are a stub for the first method
+					//MethodOne.call(params)
+					//.then(() => MethodTwo.call())
+					//.catch(err => log(err));
+
+					DDP._CurrentMethodInvocation._setCallAsyncMethodRunning(false);
+
+					if (err) reject(err);
+					resolve(serverResult);
+				}
+			),
+			isThenable = clientResultOrThenable && typeof clientResultOrThenable.then === 'function';
+
+			//catch exceptions on the stub and re-route them to the promise wrapper
+			if (isThenable) clientResultOrThenable.catch(err => reject(err));
+		});
+  }
+
   _execute(methodInvocation = {}, args) {
     // Add `this.name` to reference the Method name
     methodInvocation.name = this.name;


### PR DESCRIPTION
A pull request for a `callAsync` method we have been using internally for a while now.
It should be noted that the callback on `Meteor.applyAsync` will probably disappear in time and this is only going to work until it does.

This implementation checks all of the boxes for our needs:
- Will catch stub errors as promise rejections and keep the server from running the method if it does
- Will correctly mark a method as no longer running when its promise has been returned to allow for chaining of multiple async methods
- Will not log `Exception while running simulation` to the browser
- Will not throw `Access denied` errors in the browser by using `Meteor.applyAsync`
