### PR TITLE
Added an _executeAsync method for async validated method testing

### DIFF
--- a/validated-method.js
+++ b/validated-method.js
@@ -140,6 +140,23 @@ perhaps you meant to throw an error?`);
 
     return this.run.bind(methodInvocation)(args);
   }
+
+  _executeAsync(methodInvocation = {}, args) {
+	//Add `this.name` to reference the Method name
+	methodInvocation.name = this.name;
+
+	try {
+		const validateResult = this.validate.bind(methodInvocation)(args);
+
+		if (typeof validateResult !== 'undefined') {
+			throw new Error('Returning from validate doesn\'t do anything; Perhaps you meant to throw an error?');
+		}
+
+		return this.run.bind(methodInvocation)(args);
+	} catch (err) {
+		return Promise.reject(err);
+	}
+  }
 };
 
 // Mixins get a chance to transform the arguments before they are passed to the actual Method


### PR DESCRIPTION
Once updated to 1.3, I realized I had forgotten my async testing method in the first pull request.
This _executeAsync will return errors thrown by the `validate` as promise rejections so they can be tested for using https://www.chaijs.com/plugins/chai-as-promised/